### PR TITLE
Integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/sptfy](https://hexdocs.pm/sptfy).
 
+## Development
+
+```console
+# Unit tests
+$ mix test
+
+# Integration tests
+$ SPOTIFY_TOKEN="..." mix test ./integration_test
+```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ be found at [https://hexdocs.pm/sptfy](https://hexdocs.pm/sptfy).
 
 ## Development
 
-```console
+```shell
 # Unit tests
 $ mix test
 

--- a/integration_test/track_test.exs
+++ b/integration_test/track_test.exs
@@ -1,0 +1,13 @@
+defmodule IntegrationTest.TrackTest do
+  use ExUnit.Case
+
+  alias Sptfy.Track
+
+  setup_all do
+    %{token: System.fetch_env!("SPOTIFY_TOKEN")}
+  end
+
+  test "get_track/2", %{token: token} do
+    Track.get_track(token, id: "3n3Ppam7vgaVa1iaRUc9Lp") |> IO.inspect
+  end
+end

--- a/integration_test/track_test.exs
+++ b/integration_test/track_test.exs
@@ -2,12 +2,13 @@ defmodule IntegrationTest.TrackTest do
   use ExUnit.Case
 
   alias Sptfy.Track
+  alias Sptfy.Object.FullTrack
 
   setup_all do
     %{token: System.fetch_env!("SPOTIFY_TOKEN")}
   end
 
   test "get_track/2", %{token: token} do
-    Track.get_track(token, id: "3n3Ppam7vgaVa1iaRUc9Lp") |> IO.inspect
+    assert {:ok, %FullTrack{}} = Track.get_track(token, id: "3n3Ppam7vgaVa1iaRUc9Lp")
   end
 end

--- a/integration_test/track_test.exs
+++ b/integration_test/track_test.exs
@@ -2,13 +2,29 @@ defmodule IntegrationTest.TrackTest do
   use ExUnit.Case
 
   alias Sptfy.Track
-  alias Sptfy.Object.FullTrack
+  alias Sptfy.Object.{AudioFeature, FullTrack}
 
   setup_all do
-    %{token: System.fetch_env!("SPOTIFY_TOKEN")}
+    %{token: System.fetch_env!("SPOTIFY_TOKEN"), track_id: "3KtsRijwp8KunCRYlOdWEi"}
   end
 
-  test "get_track/2", %{token: token} do
-    assert {:ok, %FullTrack{}} = Track.get_track(token, id: "3n3Ppam7vgaVa1iaRUc9Lp")
+  test "get_tracks/2", %{token: token, track_id: track_id} do
+    assert {:ok, [%FullTrack{}]} = Track.get_tracks(token, ids: [track_id])
+  end
+
+  test "get_track/2", %{token: token, track_id: track_id} do
+    assert {:ok, %FullTrack{}} = Track.get_track(token, id: track_id)
+  end
+
+  test "get_tracks_audio_features/2", %{token: token, track_id: track_id} do
+    assert {:ok, [%AudioFeature{}]} = Track.get_tracks_audio_features(token, ids: [track_id])
+  end
+
+  test "get_track_audio_features/2", %{token: token, track_id: track_id} do
+    assert {:ok, %AudioFeature{}} = Track.get_track_audio_features(token, id: track_id)
+  end
+
+  test "get_audio_analysis/2", %{token: token, track_id: track_id} do
+    assert {:ok, %{}} = Track.get_audio_analysis(token, id: track_id)
   end
 end

--- a/lib/sptfy/object/album.ex
+++ b/lib/sptfy/object/album.ex
@@ -16,6 +16,7 @@ defmodule Sptfy.Object.Album do
     release_date
     release_date_precision
     restrictions
+    total_tracks
     type
     uri
   ]a

--- a/lib/sptfy/track.ex
+++ b/lib/sptfy/track.ex
@@ -9,7 +9,7 @@ defmodule Sptfy.Track do
     mapping: list_of(FullTrack, "tracks"),
     return_type: [FullTrack.t()]
 
-  get "/v1/track/:id",
+  get "/v1/tracks/:id",
     as: :get_track,
     query: [:market],
     mapping: single(FullTrack),

--- a/test/sptfy/track_test.exs
+++ b/test/sptfy/track_test.exs
@@ -24,7 +24,7 @@ defmodule Sptfy.TrackTest do
 
   describe "get_track/2" do
     test "returns a Track struct" do
-      with_mock Sptfy.Client.HTTP, get: fn _, "/v1/track/abc", _ -> TestHelpers.response(track_json()) end do
+      with_mock Sptfy.Client.HTTP, get: fn _, "/v1/tracks/abc", _ -> TestHelpers.response(track_json()) end do
         assert {:ok, %FullTrack{}} = Track.get_track("token", id: "abc")
       end
     end


### PR DESCRIPTION
Actually send requests to Spotify API not only to minimize gaps between library implementation and API response, also to detect undocumented behaviors. Only run when access token is given via environment variable.