### PR TITLE
Purge mapping DSL

### DIFF
--- a/lib/sptfy/album.ex
+++ b/lib/sptfy/album.ex
@@ -15,7 +15,7 @@ defmodule Sptfy.Album do
   get "/v1/albums/:id",
     as: :get_album,
     query: [:market],
-    mapping: single(FullAlbum)
+    mapping: {:single, module: FullAlbum}
 
   get "/v1/albums/:id/tracks",
     as: :get_album_tracks,

--- a/lib/sptfy/album.ex
+++ b/lib/sptfy/album.ex
@@ -10,7 +10,7 @@ defmodule Sptfy.Album do
   get "/v1/albums",
     as: :get_albums,
     query: [:ids, :market],
-    mapping: list_of(FullAlbum, "albums")
+    mapping: {:list, module: FullAlbum, key: "albums"}
 
   get "/v1/albums/:id",
     as: :get_album,
@@ -20,5 +20,5 @@ defmodule Sptfy.Album do
   get "/v1/albums/:id/tracks",
     as: :get_album_tracks,
     query: [:market, :limit, :offset],
-    mapping: paged(SimplifiedTrack)
+    mapping: {:paging, module: SimplifiedTrack}
 end

--- a/lib/sptfy/artist.ex
+++ b/lib/sptfy/artist.ex
@@ -10,7 +10,7 @@ defmodule Sptfy.Artist do
   get "/v1/artists",
     as: :get_artists,
     query: [:ids],
-    mapping: list_of(FullArtist, "artists")
+    mapping: {:list, module: FullArtist, key: "artists"}
 
   get "/v1/artists/:id",
     as: :get_artist,
@@ -20,15 +20,15 @@ defmodule Sptfy.Artist do
   get "/v1/artists/:id/top-tracks",
     as: :get_top_tracks,
     query: [:market],
-    mapping: list_of(FullTrack, "tracks")
+    mapping: {:list, module: FullTrack, key: "tracks"}
 
   get "/v1/artists/:id/related-artists",
     as: :get_related_artists,
     query: [],
-    mapping: list_of(FullArtist, "artists")
+    mapping: {:list, module: FullArtist, key: "artists"}
 
   get "/v1/artists/:id/albums",
     as: :get_albums,
     query: [:include_groups, :market, :limit, :offset],
-    mapping: paged(SimplifiedAlbum)
+    mapping: {:paging, module: SimplifiedAlbum}
 end

--- a/lib/sptfy/artist.ex
+++ b/lib/sptfy/artist.ex
@@ -15,7 +15,7 @@ defmodule Sptfy.Artist do
   get "/v1/artists/:id",
     as: :get_artist,
     query: [],
-    mapping: single(FullArtist)
+    mapping: {:single, module: FullArtist}
 
   get "/v1/artists/:id/top-tracks",
     as: :get_top_tracks,

--- a/lib/sptfy/browse.ex
+++ b/lib/sptfy/browse.ex
@@ -10,17 +10,17 @@ defmodule Sptfy.Browse do
   get "/v1/browse/new-releases",
     as: :get_new_releases,
     query: [:country, :limit, :offset],
-    mapping: paged(SimplifiedAlbum, "albums")
+    mapping: {:paging, module: SimplifiedAlbum, key: "albums"}
 
   get "/v1/browse/featured-playlists",
     as: :get_featured_playlists,
     query: [:country, :locale, :timestamp, :limit, :offset],
-    mapping: paged_with_message(SimplifiedPlaylist, "playlists")
+    mapping: {:paging_with_message, module: SimplifiedPlaylist, key: "playlists"}
 
   get "/v1/browse/categories",
     as: :get_categories,
     query: [:country, :locale, :timestamp, :limit, :offset],
-    mapping: paged(Category, "categories")
+    mapping: {:paging, module: Category, key: "categories"}
 
   get "/v1/browse/categories/:id",
     as: :get_category,
@@ -30,7 +30,7 @@ defmodule Sptfy.Browse do
   get "/v1/browse/categories/:id/playlists",
     as: :get_category_playlists,
     query: [:country, :limit, :offset],
-    mapping: paged(SimplifiedPlaylist, "playlists")
+    mapping: {:paging, module: SimplifiedPlaylist, key: "playlists"}
 
   get "/v1/recommendations",
     as: :get_recommendations,
@@ -88,6 +88,6 @@ defmodule Sptfy.Browse do
   get "/v1/recommendations/available-genre-seeds",
     as: :get_genres,
     query: [],
-    mapping: as_is("genres"),
+    mapping: {:as_is, key: "genres"},
     return_type: {:ok, [String.t()]}
 end

--- a/lib/sptfy/browse.ex
+++ b/lib/sptfy/browse.ex
@@ -25,7 +25,7 @@ defmodule Sptfy.Browse do
   get "/v1/browse/categories/:id",
     as: :get_category,
     query: [:country, :locale],
-    mapping: single(Category)
+    mapping: {:single, module: Category}
 
   get "/v1/browse/categories/:id/playlists",
     as: :get_category_playlists,
@@ -83,7 +83,7 @@ defmodule Sptfy.Browse do
       max_valence
       target_valence
     ]a,
-    mapping: single(Recommendation)
+    mapping: {:single, module: Recommendation}
 
   get "/v1/recommendations/available-genre-seeds",
     as: :get_genres,

--- a/lib/sptfy/client/body_mapper.ex
+++ b/lib/sptfy/client/body_mapper.ex
@@ -10,17 +10,17 @@ defmodule Sptfy.Client.BodyMapper do
 
   @spec map(json :: map() | list(map()), mapping :: t()) :: :ok | {:ok, map()} | {:ok, [map()]} | {:ok, map(), String.t()}
   def map(json, {:single, module: module}) do
-    {:ok, module.new(json)}
+    {:ok, new_struct(module, json)}
   end
 
   def map(json, {:list, module: module}) do
-    structs = json |> Enum.map(&module.new/1)
+    structs = json |> Enum.map(fn fields -> new_struct(module, fields) end)
 
     {:ok, structs}
   end
 
   def map(json, {:list, module: module, key: key}) do
-    structs = json |> Map.get(key) |> Enum.map(&module.new/1)
+    structs = json |> Map.get(key) |> Enum.map(fn fields -> new_struct(module, fields) end)
 
     {:ok, structs}
   end
@@ -60,5 +60,13 @@ defmodule Sptfy.Client.BodyMapper do
 
   def map(_json, :ok) do
     :ok
+  end
+
+  defp new_struct(_module, nil) do
+    nil
+  end
+
+  defp new_struct(module, fields) do
+    module.new(fields)
   end
 end

--- a/lib/sptfy/client/body_mapper.ex
+++ b/lib/sptfy/client/body_mapper.ex
@@ -1,14 +1,18 @@
 defmodule Sptfy.Client.BodyMapper do
   @moduledoc false
 
-  @type t :: %__MODULE__{}
+  @type mapped_result :: :ok | {:ok, map()} | {:ok, [map()]} | {:ok, map(), String.t()}
+  @type mapping :: single_mapping() | list_mapping() | paging_mapping() | as_is_mapping() | :ok
+  @typep single_mapping :: {:single, module: module()} | {:single, module: module(), key: String.t()}
+  @typep list_mapping :: {:list, module: module()} | {:list, module: module(), key: String.t()}
+  @typep paging_mapping ::
+          {:paging, module: module()}
+          | {:paging, module: module(), key: String.t()}
+          | {:paging_with_message, module: module(), key: String.t()}
+          | {:cursor_paging, module: module()}
+  @typep as_is_mapping :: :as_is | {:as_is, key: String.t()}
 
-  defstruct ~w[
-    fun
-    key
-  ]a
-
-  @spec map(json :: map() | list(map()), mapping :: t()) :: :ok | {:ok, map()} | {:ok, [map()]} | {:ok, map(), String.t()}
+  @spec map(json :: map() | list(map()), mapping :: mapping()) :: mapped_result()
   def map(json, {:single, module: module}) do
     {:ok, new_struct(module, json)}
   end

--- a/lib/sptfy/client/body_mapper.ex
+++ b/lib/sptfy/client/body_mapper.ex
@@ -6,10 +6,10 @@ defmodule Sptfy.Client.BodyMapper do
   @typep single_mapping :: {:single, module: module()} | {:single, module: module(), key: String.t()}
   @typep list_mapping :: {:list, module: module()} | {:list, module: module(), key: String.t()}
   @typep paging_mapping ::
-          {:paging, module: module()}
-          | {:paging, module: module(), key: String.t()}
-          | {:paging_with_message, module: module(), key: String.t()}
-          | {:cursor_paging, module: module()}
+           {:paging, module: module()}
+           | {:paging, module: module(), key: String.t()}
+           | {:paging_with_message, module: module(), key: String.t()}
+           | {:cursor_paging, module: module()}
   @typep as_is_mapping :: :as_is | {:as_is, key: String.t()}
 
   @spec map(json :: map() | list(map()), mapping :: mapping()) :: mapped_result()

--- a/lib/sptfy/client/body_mapper.ex
+++ b/lib/sptfy/client/body_mapper.ex
@@ -17,9 +17,8 @@ defmodule Sptfy.Client.BodyMapper do
     Map.get(json, key) |> fun.()
   end
 
-  @spec single(module :: module()) :: t()
-  def single(module) do
-    %__MODULE__{fun: fn fields -> {:ok, module.new(fields)} end}
+  def map(json, {:single, module: module}) do
+    {:ok, module.new(json)}
   end
 
   defp do_single(module) do

--- a/lib/sptfy/client/body_mapper.ex
+++ b/lib/sptfy/client/body_mapper.ex
@@ -21,6 +21,55 @@ defmodule Sptfy.Client.BodyMapper do
     {:ok, module.new(json)}
   end
 
+  def map(json, {:list, module: module}) do
+    structs = json |> Enum.map(&module.new/1)
+
+    {:ok, structs}
+  end
+
+  def map(json, {:list, module: module, key: key}) do
+    structs = json |> Map.get(key) |> Enum.map(&module.new/1)
+
+    {:ok, structs}
+  end
+
+  def map(json, {:paging, module: module}) do
+    paging = json |> Sptfy.Object.Paging.new(module)
+
+    {:ok, paging}
+  end
+
+  def map(json, {:paging, module: module, key: key}) do
+    paging = json |> Map.get(key) |> Sptfy.Object.Paging.new(module)
+
+    {:ok, paging}
+  end
+
+  def map(json, {:paging_with_message, module: module, key: key}) do
+    %{"message" => message, ^key => fields} = json
+    paging = Sptfy.Object.Paging.new(fields, module)
+
+    {:ok, paging, message}
+  end
+
+  def map(json, {:cursor_paging, module: module}) do
+    paging = json |> Sptfy.Object.CursorPaging.new(module)
+
+    {:ok, paging}
+  end
+
+  def map(json, :as_is) do
+    {:ok, json}
+  end
+
+  def map(json, {:as_is, key: key}) do
+    {:ok, Map.get(json, key)}
+  end
+
+  def map(_json, :ok) do
+    :ok
+  end
+
   defp do_single(module) do
     fn
       nil -> nil

--- a/lib/sptfy/client/body_mapper.ex
+++ b/lib/sptfy/client/body_mapper.ex
@@ -9,14 +9,6 @@ defmodule Sptfy.Client.BodyMapper do
   ]a
 
   @spec map(json :: map() | list(map()), mapping :: t()) :: :ok | {:ok, map()} | {:ok, [map()]} | {:ok, map(), String.t()}
-  def map(json, %__MODULE__{fun: fun, key: nil}) do
-    fun.(json)
-  end
-
-  def map(json, %__MODULE__{fun: fun, key: key}) do
-    Map.get(json, key) |> fun.()
-  end
-
   def map(json, {:single, module: module}) do
     {:ok, module.new(json)}
   end
@@ -68,50 +60,5 @@ defmodule Sptfy.Client.BodyMapper do
 
   def map(_json, :ok) do
     :ok
-  end
-
-  defp do_single(module) do
-    fn
-      nil -> nil
-      fields -> module.new(fields)
-    end
-  end
-
-  @spec list_of(module :: module(), key :: String.t() | nil) :: t()
-  def list_of(module, key \\ nil) do
-    single_fun = do_single(module)
-    %__MODULE__{fun: fn list -> {:ok, Enum.map(list, single_fun)} end, key: key}
-  end
-
-  @spec paged(module :: module(), key :: String.t() | nil) :: t()
-  def paged(module, key \\ nil) do
-    %__MODULE__{fun: fn fields -> {:ok, Sptfy.Object.Paging.new(fields, module)} end, key: key}
-  end
-
-  @spec paged_with_message(module :: module(), key :: String.t() | nil) :: t()
-  def paged_with_message(module, key \\ nil) do
-    fun = fn fields ->
-      %{"message" => message, ^key => pagign_fields} = fields
-      paging = Sptfy.Object.Paging.new(pagign_fields, module)
-
-      {:ok, paging, message}
-    end
-
-    %__MODULE__{fun: fun, key: nil}
-  end
-
-  @spec cursor_paged(module :: module()) :: t()
-  def cursor_paged(module) do
-    %__MODULE__{fun: fn fields -> {:ok, Sptfy.Object.CursorPaging.new(fields, module)} end}
-  end
-
-  @spec as_is(key :: String.t() | nil) :: t()
-  def as_is(key \\ nil) do
-    %__MODULE__{fun: fn fields -> {:ok, fields} end, key: key}
-  end
-
-  @spec ok :: t()
-  def ok do
-    %__MODULE__{fun: fn _ -> :ok end}
   end
 end

--- a/lib/sptfy/client/response_handler.ex
+++ b/lib/sptfy/client/response_handler.ex
@@ -4,9 +4,9 @@ defmodule Sptfy.Client.ResponseHandler do
   alias Sptfy.Client.BodyMapper
   alias Sptfy.Object.Error
 
-  @type handled_response :: :ok | {:ok, map()} | {:ok, [map()]} | {:ok, map(), String.t()} | {:error, Error.t()}
+  @type handled_response :: BodyMapper.mapped_result() | {:error, Error.t()}
 
-  @spec handle(response :: %Finch.Response{}, mapping :: BodyMapper.t()) :: handled_response()
+  @spec handle(response :: %Finch.Response{}, mapping :: BodyMapper.mapping()) :: handled_response()
   def handle(%Finch.Response{body: body}, mapping) do
     case Jason.decode(body) do
       {:ok, json} -> handle_json(json, mapping)

--- a/lib/sptfy/client/return_type.ex
+++ b/lib/sptfy/client/return_type.ex
@@ -2,7 +2,7 @@ defmodule Sptfy.Client.ReturnType do
   @moduledoc false
 
   @doc false
-  @spec ast(type :: tuple() | atom()) :: tuple() | :ok | nil
+  @spec ast(mapping :: Sptfy.Client.BodyMapper.mappgin()) :: tuple() | :ok | nil
   def ast({:single, module: module}) do
     ok(t(module))
   end

--- a/lib/sptfy/client/return_type.ex
+++ b/lib/sptfy/client/return_type.ex
@@ -2,7 +2,7 @@ defmodule Sptfy.Client.ReturnType do
   @moduledoc false
 
   @doc false
-  @spec ast(mapping :: Sptfy.Client.BodyMapper.mappgin()) :: tuple() | :ok | nil
+  @spec ast(mapping :: Sptfy.Client.BodyMapper.mapping()) :: tuple() | :ok | nil
   def ast({:single, module: module}) do
     ok(t(module))
   end

--- a/lib/sptfy/client/return_type.ex
+++ b/lib/sptfy/client/return_type.ex
@@ -7,6 +7,10 @@ defmodule Sptfy.Client.ReturnType do
     ok(t(module))
   end
 
+  def ast({:single, module: module}) do
+    ok(t(module))
+  end
+
   def ast({:list_of, _meta, [module | _]}) do
     ok([t(module)])
   end

--- a/lib/sptfy/client/return_type.ex
+++ b/lib/sptfy/client/return_type.ex
@@ -2,17 +2,9 @@ defmodule Sptfy.Client.ReturnType do
   @moduledoc false
 
   @doc false
-  @spec ast(tuple()) :: tuple() | :ok | nil
-  def ast({:single, _meta, [module | _]}) do
-    ok(t(module))
-  end
-
+  @spec ast(type :: tuple() | atom()) :: tuple() | :ok | nil
   def ast({:single, module: module}) do
     ok(t(module))
-  end
-
-  def ast({:list_of, _meta, [module | _]}) do
-    ok([t(module)])
   end
 
   def ast({:list, opts}) do
@@ -21,32 +13,16 @@ defmodule Sptfy.Client.ReturnType do
     ok([t(module)])
   end
 
-  def ast({:paged, _meta, _args}) do
-    ok(t(Sptfy.Object.Paging))
-  end
-
   def ast({:paging, _opts}) do
     ok(t(Sptfy.Object.Paging))
-  end
-
-  def ast({:paged_with_message, _meta, _args}) do
-    {:{}, [], [:ok, t(Sptfy.Object.Paging), t(String)]}
   end
 
   def ast({:paging_with_message, _opts}) do
     {:{}, [], [:ok, t(Sptfy.Object.Paging), t(String)]}
   end
 
-  def ast({:cursor_paged, _meta, _args}) do
-    ok(t(Sptfy.Object.CursorPaging))
-  end
-
   def ast({:cursor_paging, _opts}) do
     ok(t(Sptfy.Object.CursorPaging))
-  end
-
-  def ast({:as_is, _meta, _args}) do
-    nil
   end
 
   def ast(:as_is) do

--- a/lib/sptfy/client/return_type.ex
+++ b/lib/sptfy/client/return_type.ex
@@ -15,7 +15,17 @@ defmodule Sptfy.Client.ReturnType do
     ok([t(module)])
   end
 
+  def ast({:list, opts}) do
+    module = Keyword.get(opts, :module)
+
+    ok([t(module)])
+  end
+
   def ast({:paged, _meta, _args}) do
+    ok(t(Sptfy.Object.Paging))
+  end
+
+  def ast({:paging, _opts}) do
     ok(t(Sptfy.Object.Paging))
   end
 
@@ -23,7 +33,15 @@ defmodule Sptfy.Client.ReturnType do
     {:{}, [], [:ok, t(Sptfy.Object.Paging), t(String)]}
   end
 
+  def ast({:paging_with_message, _opts}) do
+    {:{}, [], [:ok, t(Sptfy.Object.Paging), t(String)]}
+  end
+
   def ast({:cursor_paged, _meta, _args}) do
+    ok(t(Sptfy.Object.CursorPaging))
+  end
+
+  def ast({:cursor_paging, _opts}) do
     ok(t(Sptfy.Object.CursorPaging))
   end
 
@@ -31,7 +49,15 @@ defmodule Sptfy.Client.ReturnType do
     nil
   end
 
-  def ast({:ok, _meta, _args}) do
+  def ast(:as_is) do
+    nil
+  end
+
+  def ast({:as_is, _opts}) do
+    nil
+  end
+
+  def ast(:ok) do
     :ok
   end
 

--- a/lib/sptfy/episode.ex
+++ b/lib/sptfy/episode.ex
@@ -15,5 +15,5 @@ defmodule Sptfy.Episode do
   get "/v1/episodes/:id",
     as: :get_episode,
     query: [:market],
-    mapping: single(FullEpisode)
+    mapping: {:single, module: FullEpisode}
 end

--- a/lib/sptfy/episode.ex
+++ b/lib/sptfy/episode.ex
@@ -10,7 +10,7 @@ defmodule Sptfy.Episode do
   get "/v1/episodes",
     as: :get_episodes,
     query: [:ids, :market],
-    mapping: list_of(FullEpisode, "episodes")
+    mapping: {:list, module: FullEpisode, key: "episodes"}
 
   get "/v1/episodes/:id",
     as: :get_episode,

--- a/lib/sptfy/follow.ex
+++ b/lib/sptfy/follow.ex
@@ -11,58 +11,58 @@ defmodule Sptfy.Follow do
     as: :follow_playlist,
     query: [],
     body: [:public],
-    mapping: ok()
+    mapping: :ok
 
   delete "/v1/playlists/:id/followers",
     as: :unfollow_playlist,
     query: [],
     body: [],
-    mapping: ok()
+    mapping: :ok
 
   get "/v1/playlists/:id/followers/contains",
     as: :check_playlist_following_state,
     query: [:ids],
-    mapping: as_is(),
+    mapping: :as_is,
     return_type: {:ok, [boolean()]}
 
   get "/v1/me/following",
     as: :get_my_following_artists,
     query: [:after, :limit, {:type, "artist"}],
-    mapping: paged(FullArtist, "artists")
+    mapping: {:paging, module: FullArtist, key: "artists"}
 
   put "/v1/me/following",
     as: :follow_users,
     query: [type: "user"],
     body: [:ids],
-    mapping: ok()
+    mapping: :ok
 
   put "/v1/me/following",
     as: :follow_artists,
     query: [type: "artist"],
     body: [:ids],
-    mapping: ok()
+    mapping: :ok
 
   delete "/v1/me/following",
     as: :unfollow_users,
     query: [type: "user"],
     body: [:ids],
-    mapping: ok()
+    mapping: :ok
 
   delete "/v1/me/following",
     as: :unfollow_artists,
     query: [type: "artist"],
     body: [:ids],
-    mapping: ok()
+    mapping: :ok
 
   get "/v1/me/following/contains",
     as: :check_my_user_following_state,
     query: [:ids, {:type, "user"}],
-    mapping: as_is(),
+    mapping: :as_is,
     return_type: {:ok, [boolean()]}
 
   get "/v1/me/following/contains",
     as: :check_my_artist_following_state,
     query: [:ids, {:type, "artist"}],
-    mapping: as_is(),
+    mapping: :as_is,
     return_type: {:ok, [boolean()]}
 end

--- a/lib/sptfy/library.ex
+++ b/lib/sptfy/library.ex
@@ -10,69 +10,69 @@ defmodule Sptfy.Library do
   get "/v1/me/albums",
     as: :get_saved_albums,
     query: [:limit, :offset, :market],
-    mapping: paged(SavedAlbum)
+    mapping: {:paging, module: SavedAlbum}
 
   put "/v1/me/albums",
     as: :save_albums,
     query: [],
     body: [:ids],
-    mapping: ok()
+    mapping: :ok
 
   delete "/v1/me/albums",
     as: :remove_from_saved_albums,
     query: [],
     body: [:ids],
-    mapping: ok()
+    mapping: :ok
 
   get "/v1/me/albums/contains",
     as: :check_albums_saved_state,
     query: [:ids],
-    mapping: as_is(),
+    mapping: :as_is,
     return_type: {:ok, [boolean()]}
 
   get "/v1/me/tracks",
     as: :get_saved_tracks,
     query: [:limit, :offset, :market],
-    mapping: paged(SavedTrack)
+    mapping: {:paging, module: SavedTrack}
 
   put "/v1/me/tracks",
     as: :save_tracks,
     query: [],
     body: [:ids],
-    mapping: ok()
+    mapping: :ok
 
   delete "/v1/me/tracks",
     as: :remove_from_saved_tracks,
     query: [],
     body: [:ids],
-    mapping: ok()
+    mapping: :ok
 
   get "/v1/me/tracks/contains",
     as: :check_tracks_saved_state,
     query: [:ids],
-    mapping: as_is(),
+    mapping: :as_is,
     return_type: {:ok, [boolean()]}
 
   get "/v1/me/shows",
     as: :get_saved_shows,
     query: [:limit, :offset],
-    mapping: paged(SavedShow)
+    mapping: {:paging, module: SavedShow}
 
   put "/v1/me/shows",
     as: :save_shows,
     query: [],
     body: [:ids],
-    mapping: ok()
+    mapping: :ok
 
   delete "/v1/me/shows",
     as: :remove_from_saved_shows,
     query: [],
     body: [:ids],
-    mapping: ok()
+    mapping: :ok
 
   get "/v1/me/shows/contains",
     as: :check_shows_saved_state,
     query: [:ids],
-    mapping: as_is(),
+    mapping: :as_is,
     return_type: {:ok, [boolean()]}
 end

--- a/lib/sptfy/object.ex
+++ b/lib/sptfy/object.ex
@@ -11,7 +11,6 @@ defmodule Sptfy.Object do
       alias Sptfy.Object.Helpers
 
       @doc false
-      def new(nil), do: nil
       def new(fields), do: struct(__MODULE__, Helpers.atomize_keys(fields))
 
       defoverridable new: 1

--- a/lib/sptfy/personalization.ex
+++ b/lib/sptfy/personalization.ex
@@ -10,10 +10,10 @@ defmodule Sptfy.Personalization do
   get "/v1/me/top/artists",
     as: :get_top_artists,
     query: [:time_range, :limit, :offset],
-    mapping: paged(FullArtist)
+    mapping: {:paging, module: FullArtist}
 
   get "/v1/me/top/tracks",
     as: :get_top_tracks,
     query: [:time_range, :limit, :offset],
-    mapping: paged(FullTrack)
+    mapping: {:paging, module: FullTrack}
 end

--- a/lib/sptfy/player.ex
+++ b/lib/sptfy/player.ex
@@ -10,7 +10,7 @@ defmodule Sptfy.Player do
   get "/v1/me/player",
     as: :get_playback,
     query: [:market, :additional_types],
-    mapping: single(Playback)
+    mapping: {:single, module: Playback}
 
   put "/v1/me/player",
     as: :transfer_playback,
@@ -26,7 +26,7 @@ defmodule Sptfy.Player do
   get "/v1/me/player/currently-playing",
     as: :get_currently_playing,
     query: [:market, :additional_types],
-    mapping: single(CurrentlyPlaying)
+    mapping: {:single, module: CurrentlyPlaying}
 
   put "/v1/me/player/play",
     as: :play,

--- a/lib/sptfy/player.ex
+++ b/lib/sptfy/player.ex
@@ -16,12 +16,12 @@ defmodule Sptfy.Player do
     as: :transfer_playback,
     query: [],
     body: [:device_ids, :play],
-    mapping: ok()
+    mapping: :ok
 
   get "/v1/me/player/devices",
     as: :get_devices,
     query: [],
-    mapping: list_of(Device, "devices")
+    mapping: {:list, module: Device, key: "devices"}
 
   get "/v1/me/player/currently-playing",
     as: :get_currently_playing,
@@ -32,58 +32,58 @@ defmodule Sptfy.Player do
     as: :play,
     query: [:device_id],
     body: [:context_uri, :uris, :offset, :position_ms],
-    mapping: ok()
+    mapping: :ok
 
   put "/v1/me/player/pause",
     as: :pause,
     query: [:device_id],
     body: [],
-    mapping: ok()
+    mapping: :ok
 
   post "/v1/me/player/next",
     as: :skip_to_next,
     query: [:device_id],
     body: [],
-    mapping: ok()
+    mapping: :ok
 
   post "/v1/me/player/previous",
     as: :skip_to_prev,
     query: [:device_id],
     body: [],
-    mapping: ok()
+    mapping: :ok
 
   put "/v1/me/player/seek",
     as: :seek,
     query: [:position_ms, :device_id],
     body: [],
-    mapping: ok()
+    mapping: :ok
 
   put "/v1/me/player/repeat",
     as: :set_repeat,
     query: [:state, :device_id],
     body: [],
-    mapping: ok()
+    mapping: :ok
 
   put "/v1/me/player/volume",
     as: :set_volume,
     query: [:volume_percent, :device_id],
     body: [],
-    mapping: ok()
+    mapping: :ok
 
   put "/v1/me/player/shuffle",
     as: :set_shuffle,
     query: [:state, :device_id],
     body: [],
-    mapping: ok()
+    mapping: :ok
 
   get "/v1/me/player/recently-played",
     as: :get_recently_played,
     query: [:limit, :before, :after],
-    mapping: cursor_paged(PlayHistory)
+    mapping: {:cursor_paging, module: PlayHistory}
 
   post "/v1/me/player/queue",
     as: :enqueue,
     query: [:uri, :device_id],
     body: [],
-    mapping: ok()
+    mapping: :ok
 end

--- a/lib/sptfy/playlist.ex
+++ b/lib/sptfy/playlist.ex
@@ -21,12 +21,12 @@ defmodule Sptfy.Playlist do
     as: :create_user_playlist,
     query: [],
     body: [:name, :public, :collaborative, :description],
-    mapping: single(FullPlaylist)
+    mapping: {:single, module: FullPlaylist}
 
   get "/v1/playlists/:id",
     as: :get_playlist,
     query: [:market, :fields, :additional_types],
-    mapping: single(FullPlaylist)
+    mapping: {:single, module: FullPlaylist}
 
   put "/v1/playlists/:id",
     as: :update_playlist_details,

--- a/lib/sptfy/playlist.ex
+++ b/lib/sptfy/playlist.ex
@@ -10,12 +10,12 @@ defmodule Sptfy.Playlist do
   get "/v1/me/playlists",
     as: :get_my_playlists,
     query: [:limit, :offset],
-    mapping: paged(SimplifiedPlaylist)
+    mapping: {:paging, module: SimplifiedPlaylist}
 
   get "/v1/users/:id/playlists",
     as: :get_user_playlists,
     query: [:limit, :offset],
-    mapping: paged(SimplifiedPlaylist)
+    mapping: {:paging, module: SimplifiedPlaylist}
 
   post "/v1/users/:id/playlists",
     as: :create_user_playlist,
@@ -32,44 +32,44 @@ defmodule Sptfy.Playlist do
     as: :update_playlist_details,
     query: [],
     body: [:name, :public, :collaborative, :description],
-    mapping: ok()
+    mapping: :ok
 
   get "/v1/playlists/:id/tracks",
     as: :get_playlist_tracks,
     query: [:market, :fields, :limit, :offset, :additional_types],
-    mapping: paged(PlaylistTrack)
+    mapping: {:paging, module: PlaylistTrack}
 
   post "/v1/playlists/:id/tracks",
     as: :add_tracks,
     query: [],
     body: [:uris, :position],
-    mapping: ok()
+    mapping: :ok
 
   put "/v1/playlists/:id/tracks",
     as: :replace_tracks,
     query: [],
     body: [:uris],
-    mapping: ok()
+    mapping: :ok
 
   put "/v1/playlists/:id/tracks",
     as: :reorder_tracks,
     query: [],
     body: [:range_start, :insert_before, :range_length, :snapshot_id],
-    mapping: ok()
+    mapping: :ok
 
   get "/v1/playlists/:id/images",
     as: :get_cover_images,
     query: [],
-    mapping: list_of(Image)
+    mapping: {:list, module: Image}
 
   put_jpeg "/v1/playlists/:id/images",
     as: :upload_cover_image,
     query: [],
-    mapping: ok()
+    mapping: :ok
 
   delete "/v1/playlists/:id/tracks",
     as: :remove_tracks,
     query: [],
     body: [:tracks],
-    mapping: ok()
+    mapping: :ok
 end

--- a/lib/sptfy/profile.ex
+++ b/lib/sptfy/profile.ex
@@ -10,10 +10,10 @@ defmodule Sptfy.Profile do
   get "/v1/me",
     as: :get_my_profile,
     query: [],
-    mapping: single(PrivateUser)
+    mapping: {:single, module: PrivateUser}
 
   get "/v1/users/:id",
     as: :get_profile,
     query: [],
-    mapping: single(PublicUser)
+    mapping: {:single, module: PublicUser}
 end

--- a/lib/sptfy/search.ex
+++ b/lib/sptfy/search.ex
@@ -10,30 +10,30 @@ defmodule Sptfy.Search do
   get "/v1/search",
     as: :search_album,
     query: [:q, :market, :limit, :offset, :include_external, {:type, "album"}],
-    mapping: paged(SimplifiedAlbum, "albums")
+    mapping: {:paging, module: SimplifiedAlbum, key: "albums"}
 
   get "/v1/search",
     as: :search_artist,
     query: [:q, :market, :limit, :offset, :include_external, {:type, "artist"}],
-    mapping: paged(FullArtist, "artists")
+    mapping: {:paging, module: FullArtist, key: "artists"}
 
   get "/v1/search",
     as: :search_episode,
     query: [:q, :market, :limit, :offset, :include_external, {:type, "episode"}],
-    mapping: paged(SimplifiedEpisode, "episodes")
+    mapping: {:paging, module: SimplifiedEpisode, key: "episodes"}
 
   get "/v1/search",
     as: :search_playlist,
     query: [:q, :market, :limit, :offset, :include_external, {:type, "playlist"}],
-    mapping: paged(SimplifiedPlaylist, "playlists")
+    mapping: {:paging, module: SimplifiedPlaylist, key: "playlists"}
 
   get "/v1/search",
     as: :search_show,
     query: [:q, :market, :limit, :offset, :include_external, {:type, "show"}],
-    mapping: paged(SimplifiedShow, "shows")
+    mapping: {:paging, module: SimplifiedShow, key: "shows"}
 
   get "/v1/search",
     as: :search_track,
     query: [:q, :market, :limit, :offset, :include_external, {:type, "track"}],
-    mapping: paged(FullTrack, "tracks")
+    mapping: {:paging, module: FullTrack, key: "tracks"}
 end

--- a/lib/sptfy/show.ex
+++ b/lib/sptfy/show.ex
@@ -10,7 +10,7 @@ defmodule Sptfy.Show do
   get "/v1/shows",
     as: :get_shows,
     query: [:ids, :market],
-    mapping: list_of(SimplifiedShow, "shows")
+    mapping: {:list, module: SimplifiedShow, key: "shows"}
 
   get "/v1/shows/:id",
     as: :get_show,
@@ -20,5 +20,5 @@ defmodule Sptfy.Show do
   get "/v1/shows/:id/episodes",
     as: :get_episodes,
     query: [:market, :limit, :offset],
-    mapping: paged(SimplifiedEpisode)
+    mapping: {:paging, module: SimplifiedEpisode}
 end

--- a/lib/sptfy/show.ex
+++ b/lib/sptfy/show.ex
@@ -15,7 +15,7 @@ defmodule Sptfy.Show do
   get "/v1/shows/:id",
     as: :get_show,
     query: [:market],
-    mapping: single(FullShow)
+    mapping: {:single, module: FullShow}
 
   get "/v1/shows/:id/episodes",
     as: :get_episodes,

--- a/lib/sptfy/track.ex
+++ b/lib/sptfy/track.ex
@@ -15,7 +15,7 @@ defmodule Sptfy.Track do
   get "/v1/tracks/:id",
     as: :get_track,
     query: [:market],
-    mapping: single(FullTrack)
+    mapping: {:single, module: FullTrack}
 
   get "/v1/audio-features",
     as: :get_tracks_audio_features,
@@ -25,7 +25,7 @@ defmodule Sptfy.Track do
   get "/v1/audio-features/:id",
     as: :get_track_audio_features,
     query: [],
-    mapping: single(AudioFeature)
+    mapping: {:single, module: AudioFeature}
 
   get "/v1/audio-analysis/:id",
     as: :get_audio_analysis,

--- a/lib/sptfy/track.ex
+++ b/lib/sptfy/track.ex
@@ -10,7 +10,7 @@ defmodule Sptfy.Track do
   get "/v1/tracks",
     as: :get_tracks,
     query: [:ids, :market],
-    mapping: list_of(FullTrack, "tracks")
+    mapping: {:list, module: FullTrack, key: "tracks"}
 
   get "/v1/tracks/:id",
     as: :get_track,
@@ -20,7 +20,7 @@ defmodule Sptfy.Track do
   get "/v1/audio-features",
     as: :get_tracks_audio_features,
     query: [:ids],
-    mapping: list_of(AudioFeature, "audio_features")
+    mapping: {:list, module: AudioFeature, key: "audio_features"}
 
   get "/v1/audio-features/:id",
     as: :get_track_audio_features,
@@ -30,6 +30,6 @@ defmodule Sptfy.Track do
   get "/v1/audio-analysis/:id",
     as: :get_audio_analysis,
     query: [],
-    mapping: as_is(),
+    mapping: :as_is,
     return_type: {:ok, map()}
 end

--- a/test/sptfy/client/body_mapper_test.exs
+++ b/test/sptfy/client/body_mapper_test.exs
@@ -4,9 +4,9 @@ defmodule Sptfy.Client.BodyMapperTest do
   alias Sptfy.Client.BodyMapper
   alias Sptfy.Object.{CursorPaging, Paging, SimplifiedArtist}
 
-  describe "single/1" do
+  describe "map/2 with :single tuple" do
     test "maps a json object to a struct" do
-      mapping = BodyMapper.single(SimplifiedArtist)
+      mapping = {:single, module: SimplifiedArtist}
 
       assert BodyMapper.map(%{}, mapping) == {:ok, %SimplifiedArtist{}}
       assert BodyMapper.map(%{id: 10}, mapping) == {:ok, %SimplifiedArtist{id: 10}}

--- a/test/sptfy/client/body_mapper_test.exs
+++ b/test/sptfy/client/body_mapper_test.exs
@@ -14,31 +14,39 @@ defmodule Sptfy.Client.BodyMapperTest do
     end
   end
 
-  describe "list_of/2" do
+  describe "map/2 with :list tuple" do
     test "maps a json array to list of structs" do
-      mapping = BodyMapper.list_of(SimplifiedArtist, "key")
+      mapping = {:list, module: SimplifiedArtist, key: "key"}
 
       assert BodyMapper.map(%{"key" => [%{}]}, mapping) == {:ok, [%SimplifiedArtist{}]}
       assert BodyMapper.map(%{"key" => [%{id: 10}]}, mapping) == {:ok, [%SimplifiedArtist{id: 10}]}
       assert BodyMapper.map(%{"key" => [%{"id" => 10}]}, mapping) == {:ok, [%SimplifiedArtist{id: 10}]}
     end
 
-    test "handle list when key is nil" do
-      mapping = BodyMapper.list_of(SimplifiedArtist)
+    test "handle list without key" do
+      mapping = {:list, module: SimplifiedArtist}
 
       assert BodyMapper.map([nil, %{id: 10}, nil], mapping) == {:ok, [nil, %SimplifiedArtist{id: 10}, nil]}
     end
 
     test "maps nil into nil" do
-      mapping = BodyMapper.list_of(SimplifiedArtist, "key")
+      mapping = {:list, module: SimplifiedArtist, key: "key"}
 
       assert BodyMapper.map(%{"key" => [nil, %{id: 10}, nil]}, mapping) == {:ok, [nil, %SimplifiedArtist{id: 10}, nil]}
     end
   end
 
-  describe "paged/2" do
+  describe "map/2 with :paging tuple" do
     test "maps a json object to structs wrapped by Paging" do
-      mapping = BodyMapper.paged(SimplifiedArtist)
+      mapping = {:paging, module: SimplifiedArtist, key: "key"}
+
+      assert BodyMapper.map(%{"key" => %{"items" => []}}, mapping) == {:ok, %Paging{items: []}}
+      assert BodyMapper.map(%{"key" => %{"items" => [%{id: 10}]}}, mapping) == {:ok, %Paging{items: [%SimplifiedArtist{id: 10}]}}
+      assert BodyMapper.map(%{"key" => %{"items" => [%{"id" => 10}]}}, mapping) == {:ok, %Paging{items: [%SimplifiedArtist{id: 10}]}}
+    end
+
+    test "handle without key" do
+      mapping = {:paging, module: SimplifiedArtist}
 
       assert BodyMapper.map(%{"items" => []}, mapping) == {:ok, %Paging{items: []}}
       assert BodyMapper.map(%{"items" => [%{id: 10}]}, mapping) == {:ok, %Paging{items: [%SimplifiedArtist{id: 10}]}}
@@ -46,9 +54,9 @@ defmodule Sptfy.Client.BodyMapperTest do
     end
   end
 
-  describe "cursor_paged/2" do
+  describe "map/2 with :cursor_paging tuple" do
     test "maps a json object to structs wrapped by CursorPaging" do
-      mapping = BodyMapper.cursor_paged(SimplifiedArtist)
+      mapping = {:cursor_paging, module: SimplifiedArtist}
 
       assert BodyMapper.map(%{"items" => []}, mapping) == {:ok, %CursorPaging{items: []}}
       assert BodyMapper.map(%{"items" => [%{id: 10}]}, mapping) == {:ok, %CursorPaging{items: [%SimplifiedArtist{id: 10}]}}
@@ -56,13 +64,25 @@ defmodule Sptfy.Client.BodyMapperTest do
     end
   end
 
-  describe "as_is/0" do
+  describe "map/2 with :as_is tuple" do
     test "returns given map" do
-      mapping = BodyMapper.as_is()
+      mapping = {:as_is, key: "key"}
 
-      assert BodyMapper.map(%{}, mapping) == {:ok, %{}}
-      assert BodyMapper.map(%{id: 10}, mapping) == {:ok, %{id: 10}}
-      assert BodyMapper.map(%{"id" => 10}, mapping) == {:ok, %{"id" => 10}}
+      assert BodyMapper.map(%{"key" => [true]}, mapping) == {:ok, [true]}
+    end
+
+    test "handle without key" do
+      mapping = :as_is
+
+      assert BodyMapper.map([true], mapping) == {:ok, [true]}
+    end
+  end
+
+  describe "map/2 with :ok" do
+    test "returns :ok" do
+      mapping = :ok
+
+      assert BodyMapper.map(%{}, mapping) == :ok
     end
   end
 end


### PR DESCRIPTION
`ReturnType` module pattern matches against AST of mapping DSL function calls. It is painful and hard to read so this changes these calls to literals which is composed of atom, list and 2 elements tuple. They are elixir literals but also ASTs.