### PR TITLE
Fix required params excluded

### DIFF
--- a/lib/sptfy/client/parameter.ex
+++ b/lib/sptfy/client/parameter.ex
@@ -23,7 +23,7 @@ defmodule Sptfy.Client.Parameter do
     Enum.reduce(schema, {[], %{}}, fn
       {key, opts}, {keys, fixed_values_map} ->
         case Keyword.get(opts, :fixed) do
-          nil -> {keys, fixed_values_map}
+          nil -> {[key | keys], fixed_values_map}
           value -> {keys, Map.put(fixed_values_map, key, value)}
         end
 

--- a/test/sptfy/client/parameter_test.exs
+++ b/test/sptfy/client/parameter_test.exs
@@ -5,11 +5,11 @@ defmodule Sptfy.Client.ParameterTest do
 
   describe "prepare/2" do
     setup do
-      %{schema: [:limit, :offset, {:type, fixed: "user"}]}
+      %{schema: [{:id, required: true}, :limit, :offset, {:type, fixed: "user"}]}
     end
 
     test "exclude unpermitted keys", %{schema: schema} do
-      assert Parameter.prepare(%{limit: 10, abc: 1}, schema) == %{limit: 10, type: "user"}
+      assert Parameter.prepare(%{id: "abc", limit: 10, abc: 1}, schema) == %{id: "abc", limit: 10, type: "user"}
     end
 
     test "cannot overwrite fixed value", %{schema: schema} do


### PR DESCRIPTION
Fix a bug that parameters marked as required won't be sent.

```
  1) test enqueue/2 (IntegrationTest.PlayerTest)
     integration_test/player_test.exs:78
     Assertion with == failed
     code:  assert :ok == Player.enqueue(token, uri: "spotify:track:1t18idTmPA3sWLxYUWwesw")
     left:  :ok
     right: {:error, %Sptfy.Object.Error{message: "Required parameter uri missing", status: 400}}
     stacktrace:
       integration_test/player_test.exs:79: (test)
```