### PR TITLE
Error tuples missing in Typespec

### DIFF
--- a/lib/sptfy/client.ex
+++ b/lib/sptfy/client.ex
@@ -15,7 +15,7 @@ defmodule Sptfy.Client do
 
     placeholders = Placeholder.extract(path)
     placeholder_keys = Keyword.keys(placeholders)
-    type_ast = ReturnType.ast(mapping) || Keyword.get(opts, :return_type)
+    type_ast = (ReturnType.ast(mapping) || Keyword.get(opts, :return_type)) |> ReturnType.or_error()
 
     quote location: :keep do
       @doc Document.build("GET", unquote(path), unquote(placeholders) ++ unquote(query))
@@ -46,7 +46,7 @@ defmodule Sptfy.Client do
 
     placeholders = Placeholder.extract(path)
     placeholder_keys = Keyword.keys(placeholders)
-    type_ast = ReturnType.ast(mapping) || Keyword.get(opts, :return_type)
+    type_ast = (ReturnType.ast(mapping) || Keyword.get(opts, :return_type)) |> ReturnType.or_error()
 
     quote location: :keep do
       @doc Document.build("POST", unquote(path), unquote(placeholders) ++ unquote(query) ++ unquote(body))
@@ -78,7 +78,7 @@ defmodule Sptfy.Client do
 
     placeholders = Placeholder.extract(path)
     placeholder_keys = Keyword.keys(placeholders)
-    type_ast = ReturnType.ast(mapping) || Keyword.get(opts, :return_type)
+    type_ast = (ReturnType.ast(mapping) || Keyword.get(opts, :return_type)) |> ReturnType.or_error()
 
     quote location: :keep do
       @doc Document.build("PUT", unquote(path), unquote(placeholders) ++ unquote(query) ++ unquote(body))
@@ -110,7 +110,7 @@ defmodule Sptfy.Client do
 
     placeholders = Placeholder.extract(path)
     placeholder_keys = Keyword.keys(placeholders)
-    type_ast = ReturnType.ast(mapping) || Keyword.get(opts, :return_type)
+    type_ast = (ReturnType.ast(mapping) || Keyword.get(opts, :return_type)) |> ReturnType.or_error()
 
     quote location: :keep do
       @doc Document.build("PUT", unquote(path), unquote(placeholders) ++ unquote(query))
@@ -141,7 +141,7 @@ defmodule Sptfy.Client do
 
     placeholders = Placeholder.extract(path)
     placeholder_keys = Keyword.keys(placeholders)
-    type_ast = ReturnType.ast(mapping) || Keyword.get(opts, :return_type)
+    type_ast = (ReturnType.ast(mapping) || Keyword.get(opts, :return_type)) |> ReturnType.or_error()
 
     quote location: :keep do
       @doc Document.build("DELETE", unquote(path), unquote(placeholders) ++ unquote(query) ++ unquote(body))

--- a/lib/sptfy/client/return_type.ex
+++ b/lib/sptfy/client/return_type.ex
@@ -37,8 +37,12 @@ defmodule Sptfy.Client.ReturnType do
     :ok
   end
 
-  defp t(module) do
-    {{:., [], [module, :t]}, [], []}
+  def or_error(ast) do
+    {:|, [], [ast, {:|, [], [error: t(Sptfy.Object.Error), error: t(Mint.Types, :error)]}]}
+  end
+
+  defp t(module, name \\ :t) do
+    {{:., [], [module, name]}, [], []}
   end
 
   defp ok(ast) do

--- a/lib/sptfy/client/return_type.ex
+++ b/lib/sptfy/client/return_type.ex
@@ -37,6 +37,8 @@ defmodule Sptfy.Client.ReturnType do
     :ok
   end
 
+  @doc false
+  @spec or_error(ast :: tuple()) :: tuple()
   def or_error(ast) do
     {:|, [], [ast, {:|, [], [error: t(Sptfy.Object.Error), error: t(Mint.Types, :error)]}]}
   end


### PR DESCRIPTION
All functions have chance to return following error tuples. but missing in Typespec.

- `{:error, Sptfy.Object.Error.t()}`
- `{:error, Mint.Type.error()}`