### PR TITLE
Add "Get the User's Queue" endpoint

### DIFF
--- a/integration_test/player_test.exs
+++ b/integration_test/player_test.exs
@@ -2,7 +2,7 @@ defmodule IntegrationTest.PlayerTest do
   use ExUnit.Case
 
   alias Sptfy.Player
-  alias Sptfy.Object.{CurrentlyPlaying, CursorPaging, Device, Playback, PlayHistory}
+  alias Sptfy.Object.{CurrentlyPlaying, CursorPaging, Device, FullTrack, Playback, PlayHistory, UserQueue}
 
   setup_all do
     %{token: System.fetch_env!("SPOTIFY_TOKEN")}
@@ -77,5 +77,11 @@ defmodule IntegrationTest.PlayerTest do
   @tag skip: "has side effect"
   test "enqueue/2", %{token: token} do
     assert :ok == Player.enqueue(token, uri: "spotify:track:1t18idTmPA3sWLxYUWwesw")
+  end
+
+  test "get_user_queue/1", %{token: token} do
+    assert {:ok, %UserQueue{currently_playing: currently_playing, queue: queue}} = Player.get_user_queue(token)
+    assert %FullTrack{} = currently_playing
+    assert Enum.all?(queue, fn item -> %FullTrack{} = item end)
   end
 end

--- a/lib/sptfy/object/user_queue.ex
+++ b/lib/sptfy/object/user_queue.ex
@@ -1,0 +1,27 @@
+defmodule Sptfy.Object.UserQueue do
+  @moduledoc """
+  Module for the user queue.
+  """
+
+  use Sptfy.Object
+
+  alias Sptfy.Object.FullTrack
+
+  defstruct ~w[
+    currently_playing
+    queue
+  ]a
+
+  def new(fields) do
+    fields =
+      fields
+      |> Helpers.atomize_keys()
+      |> Map.update(:currently_playing, nil, &build_currently_playing(&1))
+      |> Map.update(:queue, [], fn items -> Enum.map(items, &FullTrack.new/1) end)
+
+    struct(__MODULE__, fields)
+  end
+
+  defp build_currently_playing(_field = nil), do: nil
+  defp build_currently_playing(field), do: FullTrack.new(field)
+end

--- a/lib/sptfy/player.ex
+++ b/lib/sptfy/player.ex
@@ -5,7 +5,7 @@ defmodule Sptfy.Player do
 
   use Sptfy.Client
 
-  alias Sptfy.Object.{CurrentlyPlaying, Device, Playback, PlayHistory}
+  alias Sptfy.Object.{CurrentlyPlaying, Device, Playback, PlayHistory, UserQueue}
 
   get "/v1/me/player",
     as: :get_playback,
@@ -80,6 +80,11 @@ defmodule Sptfy.Player do
     as: :get_recently_played,
     query: [:limit, :before, :after],
     mapping: {:cursor_paging, module: PlayHistory}
+
+  get "/v1/me/player/queue",
+    as: :get_user_queue,
+    query: [],
+    mapping: {:single, module: UserQueue}
 
   post "/v1/me/player/queue",
     as: :enqueue,

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -513,4 +513,11 @@ defmodule Fixtures do
       "total" => 3
     }
   end
+
+  def user_queue do
+    %{
+      "currently_playing" => full_track(),
+      "queue" => [full_track()]
+    }
+  end
 end


### PR DESCRIPTION
Recently started using this client lib in a personal project and it has been a pleasure to work with. The [Get the User's Queue](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-queue) endpoint was probably created by Spotify only somewhat recently so I added support for it myself. I'm certainly no Elixir expert, but I hope my code matches your code quality standards, @Joe-noh :smile: